### PR TITLE
Handle hipchat's double spaces between bot name and content during the input text match, and use the correct part of the message object for showing suggestions

### DIFF
--- a/scripts/suggest.coffee
+++ b/scripts/suggest.coffee
@@ -38,7 +38,7 @@ levenshtein = (str1, str2) ->
 #
 # Returns nothing.
 showSuggestions = (examples, input, adapter, name) ->
-  inputCommand = input.text.split(" ")[1]
+  inputCommand = input.text.match(/\w+:\s+(.+)/)[1]
   return unless inputCommand
 
   suggestions = []
@@ -63,5 +63,5 @@ showSuggestions = (examples, input, adapter, name) ->
 module.exports = (robot) ->
   robot.catchAll (msg) ->
     message = msg.message
-    showSuggestions(robot.commands, message, robot.adapter, robot.name) if message.text.match ///^#{robot.name} .*$///i
+    showSuggestions(robot.commands, message, robot.adapter, robot.name) if message.match ///^#{robot.name}: .*$///i
     msg.finish()


### PR DESCRIPTION
Here is what is required for this plugin to work with HipChat (although I suspect the message.match => message.text.match may not work on other protocols).

From https://github.com/hassaku/hubot-suggest/issues/2
