### PR TITLE
Match robot name even when preceded by an "@" symbol

### DIFF
--- a/scripts/suggest.coffee
+++ b/scripts/suggest.coffee
@@ -63,5 +63,5 @@ showSuggestions = (examples, input, adapter, name) ->
 module.exports = (robot) ->
   robot.catchAll (msg) ->
     message = msg.message
-    showSuggestions(robot.commands, message, robot.adapter, robot.name) if message.text.match ///^#{robot.name} .*$///i
+    showSuggestions(robot.commands, message, robot.adapter, robot.name) if message.text.match ///^@?#{robot.name} .*$///i
     msg.finish()


### PR DESCRIPTION
In some chat services, eg Slack, you reference your bot as "@bot" -- this PR fixes the behavior of this module in such cases.