### PR TITLE
Quiet log errors when using HipChat

### DIFF
--- a/scripts/suggest.coffee
+++ b/scripts/suggest.coffee
@@ -63,5 +63,5 @@ showSuggestions = (examples, input, adapter, name) ->
 module.exports = (robot) ->
   robot.catchAll (msg) ->
     message = msg.message
-    showSuggestions(robot.commands, message, robot.adapter, robot.name) if message.text.match ///^@?#{robot.name} .*$///i
+    showSuggestions(robot.commands, message, robot.adapter, robot.name) if message.text and message.text.match ///^@?#{robot.name} .*$///i
     msg.finish()


### PR DESCRIPTION
Fixes #2 

Alternative fix to #3 where we simply check if the `message.text` property is defined before attempting to match on it.