### PR TITLE
Handle message.text being undefined

### DIFF
--- a/scripts/suggest.coffee
+++ b/scripts/suggest.coffee
@@ -63,5 +63,6 @@ showSuggestions = (examples, input, adapter, name) ->
 module.exports = (robot) ->
   robot.catchAll (msg) ->
     message = msg.message
+    message.text = message.text or ''
     showSuggestions(robot.commands, message, robot.adapter, robot.name) if message.text.match ///^@?#{robot.name} .*$///i
     msg.finish()


### PR DESCRIPTION
In particular this happens when someone parts an IRC channel but doesn't have a part message.